### PR TITLE
Fixed loading of native library when parametrized constructor was used

### DIFF
--- a/src/main/java/com/github/mbelling/ws281x/LedStripType.java
+++ b/src/main/java/com/github/mbelling/ws281x/LedStripType.java
@@ -1,0 +1,19 @@
+package com.github.mbelling.ws281x;
+
+/**
+ * Dependent on constants defined in original rpi_ws281x repository (https://github.com/jgarff/rpi_ws281x).
+ */
+public enum LedStripType {
+    SK6812_STRIP_RGBW,
+    SK6812_STRIP_RBGW,
+    SK6812_STRIP_GRBW,
+    SK6812_STRIP_GBRW,
+    SK6812_STRIP_BRGW,
+    SK6812_STRIP_BGRW,
+    WS2811_STRIP_RGB,
+    WS2811_STRIP_RBG,
+    WS2811_STRIP_GRB,
+    WS2811_STRIP_GBR,
+    WS2811_STRIP_BRG,
+    WS2811_STRIP_BGR
+}


### PR DESCRIPTION
Native .so library was loading only if default constructor was used. Method `initializeNative` is now being called in `init` method.

Added LedStripType enum that can be used instead of native constants (from .so lib). This is used in parametrized constructor instead of native constants, because they needed .so library to be loaded before calling constructor.

Added option to clear leds on exit.