### PR TITLE
Fixed getBrightness() from returning default brightness

### DIFF
--- a/src/main/java/com/github/mbelling/ws281x/Ws281xLedStrip.java
+++ b/src/main/java/com/github/mbelling/ws281x/Ws281xLedStrip.java
@@ -265,6 +265,7 @@ public class Ws281xLedStrip implements LedStrip {
     }
 
     public void setBrightness( int brightness ) {
+        this.brightness = brightness;
         currentChannel.setBrightness( (short) brightness );
     }
 


### PR DESCRIPTION
Currently **Ws281xLedStrip#getBrightness()** returns the int brightness which is set at the constructor. 

When updating the brightness using **Ws281xLedStrip#setBrightness(int)** the ws2811_channel_t's brightness gets updated but never **Ws281xLedStrip#brightness**. 

Altered the **Ws281xLedStrip#setBrightness(int)** to update the brightness so **Ws281xLedStrip#getBrightness()** returns the correct value.