### PR TITLE
[HACKTOBERFEST] Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,24 @@
 rpi281x wrapper for Java using SWIG
 
 ## TL;DR
-successfully tested on a RaspberryPi 3B+
+
+Successfully tested on a RaspberryPi 3B+
 
 1. set RaspberryPi ssh username and password in gradle.properties
 2. run `./gradlew installSwigOnPi`
 3. run `./gradlew buildNativeOnPi`
 4. run `./gradlew publishToMavenLocal -PtargetComp=11`
-5. run `./gradlew runExample -PtargetComp=11 -PamountOfLeds=16` to test. Set the amount of LEDs you want to test with the `-PamountOfLeds` property. 
-Set `-PtargetComp=11` if the java version on your raspi is 11 (often true because it's the default-jdk). Otherwise it is assumed that the java version on your raspi is the same as the one gradle uses.
-6. kill runing example java app by ssh-ing into your raspi and using `htop` to send a `SIGINT` signal to the process.
-### To build on a raspberry pi
+5. run `./gradlew runExample -PtargetComp=11 -PamountOfLeds=16` to test.<br> Set the amount of LEDs you want to test with the `-PamountOfLeds` property. <br>
+Set `-PtargetComp=11` if the java version on your raspi is 11 (often true because it's the default-jdk). Otherwise it is assumed that the java version on your raspi matches the one gradle uses.
+7. kill runing example java app by ssh-ing into your raspi and using `htop` to send a `SIGINT` signal to the process.
+
+## To build on a raspberry pi
 
 Run `src/scripts/createNativeLib.sh` to generate the SWIG java code and generate the libws2811.so native library (For a tutorial on how to install SWIG, see "Install SWIG on RaspberryPi" below).
 
 Run `./gradlew assemble` to compile the java code and create a jar containing the compile class files and the native .so file.
 
-### To build from another machine
+## To build from another machine
 
 Set the appropriate username, host and password (or path to private key) in `gradle.properties`.
 
@@ -28,7 +30,7 @@ Alternatively, you can also use the script `build-native-on-remote-pi.sh` with b
 
 This will copy the project to the pi, and run the script in the previous section, and copy the .so library back to the dev machine. After that, run `.\gradlew assemble` to compile the java code and create a jar containing the compile class files and the native .so file.  The easiest way to use the jar would be to publish it to a maven repository, or your local .m2 repository using `./gradlew publishToMavenLocal` and use maven coordinates in your maven or gradle project. 
 
-#### Install SWIG on RaspberryPi
+## To install SWIG on the RaspberryPi
 
 You can try `./gradlew installSwigOnPi` to automatically execute all the steps detailed below on your pi.
 
@@ -37,8 +39,6 @@ The default-jdk-headless which this task will try to install works only on pis w
 The script will try to detect this and install the zulu jdk as an alternative, but this has only been tested on a raspberrypi Zero so far.
 On my RasPi Zero this task took 30min the majority of which was spent building SWIG.
 On the RasPi 3 B it took 8 mins.
-
-**So proceed with caution!**
 
 You can read more in the [pi4j docs](https://pi4j.com/documentation/java-installation/).
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ Successfully tested on a RaspberryPi 3B+
 2. run `./gradlew installSwigOnPi`
 3. run `./gradlew buildNativeOnPi`
 4. run `./gradlew publishToMavenLocal -PtargetComp=11`
-5. run `./gradlew runExample -PtargetComp=11 -PamountOfLeds=16` to test.<br> Set the amount of LEDs you want to test with the `-PamountOfLeds` property. <br>
-Set `-PtargetComp=11` if the java version on your raspi is 11 (often true because it's the default-jdk). Otherwise it is assumed that the java version on your raspi matches the one gradle uses.
+5. run `./gradlew runExample -PtargetComp=11 -PamountOfLeds=16 -Pexample=RainbowExample` to test.<br>
+set `-PamountOfLeds` to the amount of LEDs on the strip. <br>
+set `-Pexample` to the name of the example-class (in src/examples) you want to execute.<br>
+set `-PtargetComp=11` if the java version on your raspi is 11 (often true because it's the default-jdk). Otherwise it is assumed that the java version on your raspi matches the one gradle uses. Only 11 can be passed currently.
 7. kill runing example java app by ssh-ing into your raspi and using `htop` to send a `SIGINT` signal to the process.
 
 ## To build on a raspberry pi

--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 rpi281x wrapper for Java using SWIG
 
 ## TL;DR
-1. Set RaspberryPi ssh username and password in gradle.properties
+successfully tested on a RaspberryPi 3B+
+
+1. set RaspberryPi ssh username and password in gradle.properties
 2. run `./gradlew installSwigOnPi`
 3. run `./gradlew buildNativeOnPi`
-4. run `./gradlew publishToMavenLocal`
-
+4. run `./gradlew publishToMavenLocal -PtargetComp=11`
+5. run `./gradlew runExample -PtargetComp=11 -PamountOfLeds=16` to test. Set the amount of LEDs you want to test with the `-PamountOfLeds` property. 
+Set `-PtargetComp=11` if the java version on your raspi is 11 (often true because it's the default-jdk). Otherwise it is assumed that the java version on your raspi is the same as the one gradle uses.
+6. kill runing example java app by ssh-ing into your raspi and using `htop` to send a `SIGINT` signal to the process.
 ### To build on a raspberry pi
 
 Run `src/scripts/createNativeLib.sh` to generate the SWIG java code and generate the libws2811.so native library (For a tutorial on how to install SWIG, see "Install SWIG on RaspberryPi" below).

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sudo apt install default-jdk-headless
 wget http://prdownloads.sourceforge.net/swig/swig-4.1.1.tar.gz
 tar -xzvf swig-4.1.1.tar.gz
 ```
-4. enter directory and start building
+4. Enter directory and start building
 ```shell
 cd swig-4.1.1
 ./configure && make

--- a/build.gradle
+++ b/build.gradle
@@ -124,8 +124,9 @@ tasks.register('buildNativeOnPi') {
 }
 tasks.register('uberExamplesJar', Jar) {
     archiveClassifier = 'uberExamples'
+    def exeClass = project.findProperty("example")
     manifest {
-        attributes 'Main-Class': 'com.github.mng.ws281x.examples.ConsecutiveTurnOnExample'
+        attributes 'Main-Class': "com.github.mng.ws281x.examples.$exeClass"
     }
     from sourceSets.examples.output
     dependsOn configurations.examplesRuntimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -5,17 +5,28 @@ plugins {
     id 'maven-publish'
     id 'signing'
 }
+
+def whichTarget = project.findProperty("targetComp");
+
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
+    if (whichTarget == "11") {
+        println("SETTING TARGET & SOURCE COMPATIBILITY JAVA VERSION TO 11!!!")
+        setSourceCompatibility JavaVersion.VERSION_11
+        setTargetCompatibility JavaVersion.VERSION_11
+    } else {
+        setSourceCompatibility JavaVersion.VERSION_17
+    }
+    withJavadocJar()
+    withSourcesJar()
 }
 
 remotes {
     rasPi {
         host = project.findProperty("RasPiHost")
         user = project.findProperty("RasPiUser")
-        if(project.hasProperty("RasPiKey")){
+        if (project.hasProperty("RasPiKey")) {
             identity = file(project.findProperty("RasPiKey"))
-        }else {
+        } else {
             password = project.findProperty("RasPiPassword")
         }
         fileTransfer = "scp"
@@ -41,6 +52,9 @@ sourceSets {
             srcDirs('build/nativeLib/')
         }
     }
+    examples {
+        java
+    }
 }
 
 jar {
@@ -48,6 +62,7 @@ jar {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
@@ -55,17 +70,22 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.32'
 
     testImplementation 'junit:junit:4.13.1'
+
+    //examplesImplementation 'com.github.mbelling:rpi-ws281x-java:2.0.0-SNAPSHOT' //doesn't work for some reason 🙄
+    examplesImplementation files("${System.properties['user.home']}/.m2/repository/com/github/mbelling/rpi-ws281x-java/2.0.0-SNAPSHOT/rpi-ws281x-java-2.0.0-SNAPSHOT.jar")
+    examplesImplementation 'org.slf4j:slf4j-api:1.7.32'
+    examplesImplementation 'org.slf4j:slf4j-simple:1.7.32'
 }
 
-tasks.register('installSwigOnPi'){
+tasks.register('installSwigOnPi') {
     description = 'try to install swig on the raspi'
     def swigDir = "~/rpi_ws281x_build/swigInstall"
-    doLast{
-        ssh.run{
-            session(remotes.rasPi){
+    doLast {
+        ssh.run {
+            session(remotes.rasPi) {
                 println("ATEMPTING TO INSTALL SWIG")
                 execute "mkdir -p $swigDir"
-                put (from:'install-swig-on-pi.sh', into: swigDir)
+                put(from: 'install-swig-on-pi.sh', into: swigDir)
                 execute "cd $swigDir; chmod +x install-swig-on-pi.sh"
                 execute("cd $swigDir; bash install-swig-on-pi.sh 1>&2") //re-route stdout to stderr so the user sees all the log output
                 println("SUCCESS!")
@@ -102,19 +122,32 @@ tasks.register('buildNativeOnPi') {
 
     }
 }
-tasks.register('finalizeBuildNative') {
-    doLast {
-        ssh.run {
-            session(remotes.rasPi) {
-
-            }
-        }
-
+tasks.register('uberExamplesJar', Jar) {
+    archiveClassifier = 'uberExamples'
+    manifest {
+        attributes 'Main-Class': 'com.github.mng.ws281x.examples.ConsecutiveTurnOnExample'
+    }
+    from sourceSets.examples.output
+    dependsOn configurations.examplesRuntimeClasspath
+    from {
+        configurations.examplesRuntimeClasspath.findAll({ it.name.endsWith("jar") }).collect { zipTree(it) }
     }
 }
 
-tasks.buildNativeOnPi.finalizedBy('finalizeBuildNative')
+def amountOfLeds = project.findProperty("amountOfLeds")
+tasks.register("runExample"){
+    doLast {
+        ssh.run {
+            session(remotes.rasPi) {
+                put from: './build/libs/rpi-ws281x-java-2.0.0-SNAPSHOT-uberExamples.jar', into: remoteBuildDir
+                executeSudo "java -jar $remoteBuildDir/rpi-ws281x-java-2.0.0-SNAPSHOT-uberExamples.jar $amountOfLeds 1>&2" //re-route stdout to stderr so the user sees all the log output
 
+            }
+        }
+    }
+}
+
+runExample.dependsOn uberExamplesJar
 
 tasks.register('checkSharedLibrary') {
     description = "Check if the shared library exists in the desired location"
@@ -129,11 +162,6 @@ tasks.register('checkSharedLibrary') {
 }
 
 compileJava.dependsOn checkSharedLibrary
-
-java {
-    withJavadocJar()
-    withSourcesJar()
-}
 
 publishing {
     publications {

--- a/src/examples/java/com/github/mng/ws281x/examples/ConsecutiveTurnOnExample.java
+++ b/src/examples/java/com/github/mng/ws281x/examples/ConsecutiveTurnOnExample.java
@@ -1,0 +1,43 @@
+package com.github.mng.ws281x.examples;
+
+
+import com.github.mbelling.ws281x.Color;
+import com.github.mbelling.ws281x.LedStripType;
+import com.github.mbelling.ws281x.Ws281xLedStrip;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConsecutiveTurnOnExample {
+    private static Logger log = LoggerFactory.getLogger(ConsecutiveTurnOnExample.class);
+
+    public static void main(String[] args) throws InterruptedException {
+        log.info("STARTING CONSECUTIVE TURN-ON EXAMPLE");
+        log.info("received args: {}", (Object[]) args);
+        int amount = Integer.parseInt(args[0]);
+        var strip = new Ws281xLedStrip(amount, 10, 800000, 0, 255, 0, false, LedStripType.WS2811_STRIP_GRB, true);
+        int curr = 0;
+        while (!Thread.interrupted()) {
+            Color col;
+            switch (curr % 3) {
+                case 0:
+                    col = Color.RED;
+                    break;
+                case 1:
+                    col = Color.GREEN;
+                    break;
+                default:
+                    col = Color.BLUE;
+                    break;
+            }
+            strip.setPixel(curr++, col);
+            if (curr > amount) {
+                curr = 0;
+                strip.setStrip(Color.BLACK);
+            }
+            log.info("rendered {}", curr);
+            strip.render();
+            Thread.sleep(1000);
+        }
+        log.info("EXITING  CONSECUTIVE TURN-ON EXAMPLE BYE!");
+    }
+}

--- a/src/examples/java/com/github/mng/ws281x/examples/RainbowExample.java
+++ b/src/examples/java/com/github/mng/ws281x/examples/RainbowExample.java
@@ -1,0 +1,52 @@
+package com.github.mng.ws281x.examples;
+
+
+import com.github.mbelling.ws281x.Color;
+import com.github.mbelling.ws281x.LedStrip;
+import com.github.mbelling.ws281x.LedStripType;
+import com.github.mbelling.ws281x.Ws281xLedStrip;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RainbowExample {
+    private static Logger log = LoggerFactory.getLogger(RainbowExample.class);
+
+    //Generate rainbow colors across 0-255 positions.
+    // taken from strandtest.py from the python rpi-ws281x project
+    private static Color wheel(int pos) {
+        if (pos < 85) {
+            return new Color(pos * 3, 255 - pos * 3, 0);
+        } else if (pos < 170) {
+            pos -= 85;
+            return new Color(255 - pos * 3, 0, pos * 3);
+        } else {
+            pos -= 170;
+            return new Color(0, pos * 3, 255 - pos * 3);
+        }
+    }
+
+    //Draw rainbow that fades across all pixels at once.
+    // taken from strandtest.py from the python rpi-ws281x project
+    private static void rainbow(LedStrip strip, int numPixels) throws InterruptedException {
+        final int wait_ms = 20;
+        final int iterations = 1;
+        for (int j = 0; j < 256 * iterations; j++) {
+            for (int i = 0; i < numPixels; i++) {
+                strip.setPixel(i, wheel((i + j) & 255));
+            }
+            strip.render();
+            Thread.sleep(wait_ms);
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        log.info("STARTING RAINBOW EXAMPLE");
+        log.info("received args: {}", (Object[]) args);
+        int amount = Integer.parseInt(args[0]);
+        var strip = new Ws281xLedStrip(amount, 10, 800000, 0, 255, 0, false, LedStripType.WS2811_STRIP_GRB, true);
+        while (!Thread.interrupted()) {
+            rainbow(strip, amount);
+        }
+        log.info("EXITING  CONSECUTIVE TURN-ON EXAMPLE BYE!");
+    }
+}


### PR DESCRIPTION
# Adds Examples

There's a new task: 'runExample' that compiles the 'examples' sourceset, and then builds an executable fatjar with the java wrapper dependency from maven local included. It deploys that to the Raspi and starts the app.

Here's the 'RainbowExample' running on a RaspberryPi 3B+:
![gif showing a RaspberryPi 3B running the 'RainbowExample' class on a LED-Strip](https://github.com/rpi-ws281x/rpi-ws281x-java/assets/113881019/502350b3-6fb8-470c-9d29-56cbd0ea13cd)
Fixes #9 and fixes #10.

@mbelling @Gadgetoid @supcik @Urmel11 any feedback is welcome. Also again, please add the label 'hacktoberfest-accepted' if you plan to accept this PR.

Thank you and Cheers!
## -MNG
